### PR TITLE
Pass the scroll id in the body of the request

### DIFF
--- a/lib/elasticsearch/api/actions/stream.rb
+++ b/lib/elasticsearch/api/actions/stream.rb
@@ -9,27 +9,27 @@ module Elasticsearch
       def stream(*args, &block)
         raise ArgumentError.new "wrong number of arguments (#{args.count} for 1..2)" if args.count > 2
         raise ArgumentError.new 'no block given' unless block_given?
-        
+
         opts, memo = *args.reverse
         opts[:scroll] = opts[:scroll] || opts['scroll'] || '5m'
-        
+
         scroll_opts = { :scroll => opts[:scroll] }
 
         catch :stop_stream do
           results = search opts
-          scroll_opts[:scroll_id] = results['_scroll_id']
-          
+          scroll_opts[:body] = results['_scroll_id']
+
           results = scroll scroll_opts if opts[:search_type] =~ /scan/
-          
+
           until results['hits']['hits'].empty? do
-            scroll_opts[:scroll_id] = results['_scroll_id']
+            scroll_opts[:body] = results['_scroll_id']
             results['hits']['hits'].each do |doc|
               memo = yield doc, memo
             end
             results = scroll scroll_opts
           end
         end
-        
+
         memo
       end
     end

--- a/lib/elasticsearch/utils/version.rb
+++ b/lib/elasticsearch/utils/version.rb
@@ -1,5 +1,5 @@
 module Elasticsearch
   module Utils
-    VERSION = "0.0.3"
+    VERSION = "0.0.4"
   end
 end


### PR DESCRIPTION
* Fixes 413 errors due to URL of the request becoming too long since _scroll_id increases in size with the number of shards